### PR TITLE
Add Context.dev Extract API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 ## Development Tools
 
 - [AlterSchema](https://alterschema.sourcemeta.com?utm_source=awesome-jsonschema) - Convert a JSON Schema definition between specification versions.
+- [Context.dev Extract API](https://www.context.dev/data/extract?utm_source=awesome-jsonschema) - Crawl a website and extract structured data matching a caller-defined JSON Schema.
 - [JSON Schema CLI](https://github.com/sourcemeta/jsonschema?utm_source=awesome-jsonschema) - A comprehensive command-line tool for working with JSON Schema supporting formatting, linting, testing, bundling, and validation across all JSON Schema versions.
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.

--- a/data.yaml
+++ b/data.yaml
@@ -530,3 +530,8 @@
   year: 2026
   type: article
   summary: A review of how every G7 government (United States, United Kingdom, France, Germany, Italy, Japan, and Canada), along with nine out of ten of the OECD's top digital governments, relies on JSON Schema for its digital public infrastructure
+
+- title: Context.dev Extract API
+  url: https://www.context.dev/data/extract
+  type: tool
+  summary: Crawl a website and extract structured data matching a caller-defined JSON Schema


### PR DESCRIPTION
## Summary

Adds the Context.dev Extract API as a development tool that accepts a caller-defined JSON Schema and returns structured web data matching that schema.

Both data.yaml and the generated README are included.

## Validation

- npm run test
- npm start
- git diff --check

## Public reference

https://www.context.dev/data/extract

## Affiliation

I work at Context.dev.