### PR TITLE
Add JSON Utility to tools list

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -535,3 +535,8 @@
   url: https://www.context.dev/data/extract
   type: tool
   summary: Crawl a website and extract structured data matching a caller-defined JSON Schema
+
+- title: JSON Utility
+  url: https://www.json-util.com/json-schema-validator
+  type: tool
+  summary: Validate JSON against a JSON Schema in your browser with clear error messages. Also includes a dedicated validator for OpenAI and Anthropic tool-calling schemas


### PR DESCRIPTION
Adds JSON Utility (https://www.json-util.com/json-schema-validator) to the tools list in data.yaml.

It validates JSON against a JSON Schema in the browser with clear error messages, and also includes a dedicated validator for OpenAI and Anthropic tool-calling schemas - checking that a schema is well-formed for function calling, and that sample arguments satisfy it, entirely client-side.

Note: I wasn't able to run `npm install && npm start` locally to regenerate README.md as CONTRIBUTING.md requests, so this PR only updates data.yaml - happy to update README.md too if a maintainer can point me to the right output, or if it's easier to regenerate on your end.