### PR TITLE
Add schema-envoy to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
+- [schema-envoy](https://github.com/tamerkalla/schema-envoy?utm_source=awesome-jsonschema) - Convert a JSON Schema to an LLM provider&#x27;s accepted keyword subset and get a machine-checked report of every constraint the conversion dropped, plus a residual validator over those dropped constraints so widened values can be rejected rather than only logged.
 
 ## Books
 

--- a/data.yaml
+++ b/data.yaml
@@ -535,3 +535,8 @@
   url: https://www.context.dev/data/extract
   type: tool
   summary: Crawl a website and extract structured data matching a caller-defined JSON Schema
+
+- title: schema-envoy
+  url: https://github.com/tamerkalla/schema-envoy
+  type: tool
+  summary: Convert a JSON Schema to an LLM provider's accepted keyword subset and get a machine-checked report of every constraint the conversion dropped, plus a residual validator over those dropped constraints so widened values can be rejected rather than only logged


### PR DESCRIPTION
Adds `schema-envoy` under tools.

Every LLM provider accepts a subset of JSON Schema, so client libraries delete the keywords the provider does not list. That deletion widens the accepted value set (the converted schema accepts instances the source schema rejects), and it is normally not reported. `schema-envoy` performs the conversion, reports every keyword it removed, and compiles a residual validator over precisely those dropped constraints, so a caller can reject a widened value rather than only learn that widening occurred.

It is distinct from Schema Gateway, already listed: that entry compiles a schema into provider-ready request payloads and lints portability. `schema-envoy`'s output is the report and the residual validator over what conversion cost, rather than the request payload.

Zero-config for the built-in provider targets, dual ESM/CJS, published with npm provenance.

I have added the entry to `data.yaml` and regenerated `README.md` with `npm install && npm start`, as CONTRIBUTING.md asks.
