### PR TITLE
Add Nutilz JSON Schema Generator to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [Context.dev Extract API](https://www.context.dev/data/extract?utm_source=awesome-jsonschema) - Crawl a website and extract structured data matching a caller-defined JSON Schema.
 - [JSON Schema CLI](https://github.com/sourcemeta/jsonschema?utm_source=awesome-jsonschema) - A comprehensive command-line tool for working with JSON Schema supporting formatting, linting, testing, bundling, and validation across all JSON Schema versions.
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
+- [Nutilz JSON Schema Generator](https://nutilz.com/json-schema-generator?utm_source=awesome-jsonschema) - A free browser-based tool to automatically generate JSON Schema definitions from JSON documents with customizable options.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
 

--- a/data.yaml
+++ b/data.yaml
@@ -535,3 +535,8 @@
   url: https://www.context.dev/data/extract
   type: tool
   summary: Crawl a website and extract structured data matching a caller-defined JSON Schema
+
+- title: Nutilz JSON Schema Generator
+  url: https://nutilz.com/json-schema-generator
+  type: tool
+  summary: A free browser-based tool to automatically generate JSON Schema definitions from JSON documents with customizable options


### PR DESCRIPTION
## Summary

Adds [Nutilz JSON Schema Generator](https://nutilz.com/json-schema-generator) to the tools section.

Nutilz JSON Schema Generator is a free browser-based developer utility that automatically infers and generates Draft-07 / 2020-12 JSON Schema definitions from JSON inputs, with support for required properties, title/description annotations, format detection, and export. Runs completely client-side without registration or tracking.

## Validation

- Validated  against  using 
- Generated  cleanly via the repo script ()
- Ran  ()
